### PR TITLE
Fix cards uploader - handle special characters properly with JSON

### DIFF
--- a/backend/src/Controller/Admin/CardsController.php
+++ b/backend/src/Controller/Admin/CardsController.php
@@ -1093,7 +1093,13 @@ class CardsController extends AppController
         if (!isset($requestData['cards'])) {
             return $this->redirect(['action' => 'uploadCards']);
         }
-        $previewedCards = json_decode(htmlspecialchars_decode($this->request->getData()['cards']), true);
+
+        $previewedCards = json_decode(htmlspecialchars_decode($requestData['cards']), true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            $this->Flash->error(__('Error: Invalid JSON format in cards data.'));
+            return $this->redirect(['action' => 'uploadCards']);
+        }
 
         $isUpdatedFields = $this->populateFields($requestData, "IsUpdated");
         $isAddedFields = $this->populateFields($requestData, "IsAdded");

--- a/backend/templates/Admin/Cards/cards_verify.php
+++ b/backend/templates/Admin/Cards/cards_verify.php
@@ -342,7 +342,7 @@
                                     <?php endif; ?>
                                 </table>
                             </div>
-                            <input type="hidden" name="cards" value='<?= json_encode($cards) ?>' />
+                            <input type="hidden" name="cards" value='<?= htmlspecialchars(json_encode($cards), ENT_QUOTES, 'UTF-8') ?>' />
                             <?php if ($errorsExist): ?>
                                 <div>
                                     <!-- Back button -->


### PR DESCRIPTION
fix(admin): escape special chars properly in json. print json error if present.

This bug caused errors in the Cards Uploader, when a single quote was used in the language or English text.