### PR TITLE
fix(composer): updated composer.json to be valid

### DIFF
--- a/backend/composer.json
+++ b/backend/composer.json
@@ -27,7 +27,7 @@
     "cakephp/authentication": "^2.4",
     "firebase/php-jwt": "^6.4",
     "cakephp/authorization": "^2.0",
-    "ozee31/cakephp-cors": "v2.0.1",
+    "ozee31/cakephp-cors": "^v2.0.1",
     "gumlet/php-image-resize": "^2.0"
   },
   "require-dev": {


### PR DESCRIPTION
composer validate --strict had 1 warning, that ozee31/cakephp-cors wasn't using a version range. now using caret version range.