### PR TITLE
fix: add missing await to  apple sign-in function

### DIFF
--- a/frontend/src/app/pages/login/login/login.component.ts
+++ b/frontend/src/app/pages/login/login/login.component.ts
@@ -332,7 +332,7 @@ export class LoginComponent implements OnInit, OnDestroy, AfterViewInit {
      */
     async handleAppleLoginBtnTap(): Promise<void> {
         try {
-            const authData = this.signInWithApple();
+            const authData = await this.signInWithApple();
             await this.handleAsyncLogin(authData);
         } catch (err) {
             this.snackbarService.handleError(err, "Sign in with Apple failed.");


### PR DESCRIPTION
This was causing the backend/api/users/login endpoint to be called before getting the proper data back from apple.