### PR TITLE
fix: classroom level icons visibility

### DIFF
--- a/frontend/src/app/pages/learning-path/classroom/classroom-classes/classroom-classes.component.html
+++ b/frontend/src/app/pages/learning-path/classroom/classroom-classes/classroom-classes.component.html
@@ -163,7 +163,7 @@
                 </div>
             </div>
             <!-- Level buttons on left side (larger screens) -->
-            <div class="landscape-leftpannel flex-md-grow-1 d-none d-md-block">
+            <div class="landscape-leftpannel flex-md-grow-1 d-none d-md-block pt-3 pr-5">
                 <ul>
                     <li *ngFor="let level of allLevels; let i = index">
                         <div [ngClass]="{ notclickable: !level.enable }">


### PR DESCRIPTION
Classroom level icons were missing two CSS classes needed prevent cropping.
<img width="581" height="455" alt="Screenshot 2025-09-22 at 1 16 49 PM" src="https://github.com/user-attachments/assets/5105836e-e97b-4020-b817-f26332745d61" />
